### PR TITLE
Fix inadvertent infinite loop in ApmStreamWrapper

### DIFF
--- a/src/Microsoft.Net.Http.Client/ApmStreamWrapper.cs
+++ b/src/Microsoft.Net.Http.Client/ApmStreamWrapper.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Net.Http.Client
 
         public override void SetLength(long value)
         {
-            SetLength(value);
+            _innerStream.SetLength(value);
         }
 
         public override void Write(byte[] buffer, int offset, int count)


### PR DESCRIPTION
This looked like it would recurse and was meant to be called on the _innerStream like everything else.